### PR TITLE
Fix for dirty users array (inherited properties)

### DIFF
--- a/mention.js
+++ b/mention.js
@@ -111,9 +111,12 @@
                                 }
                             }
                             for (i in priorities) {
-                                var j;
-                                for (j in priorities[i]) {
-                                    finals.push(priorities[i][j]);
+                                var j, priority = priorities[i];
+                                for (j in priority) {
+                                    if(priority.hasOwnProperty(j)
+                                    {
+                                        finals.push(priority[j]);
+                                    }
                                 }
                             }
                             return finals;


### PR DESCRIPTION
I came across a bug when implementing Mention.js in an Angular application. Sometimes data objects provided by Angular will include inherited methods like `forEach` in the array of items. When I would pass this user array to Mention.js it would iterate over the inherited methods and try and render them. Adding a simple `hasOwnProperty` check fixes this.
